### PR TITLE
Fixed Broken Direct Rendering Path

### DIFF
--- a/include/dr.h
+++ b/include/dr.h
@@ -27,7 +27,7 @@ typedef pvr_vertex_t plx_vertex_t;
 #define PLX_VERT	PVR_CMD_VERTEX
 #define PLX_VERT_EOS	PVR_CMD_VERTEX_EOL
 
-#define plx_dr_init(a) pvr_dr_init(*a)
+#define plx_dr_init(a) pvr_dr_init(a)
 #define plx_dr_target(a) pvr_dr_target(*a)
 #define plx_dr_commit(a) pvr_dr_commit(a)
 

--- a/include/dr.h
+++ b/include/dr.h
@@ -3,6 +3,7 @@
    dr.h
 
    Copyright (C) 2002 Megan Potter
+   Copyright (C) 2024 Falco Girgis
 
 
 */
@@ -38,6 +39,8 @@ static inline plx_vertex_t *plx_dr_target(plx_dr_state_t *state) {
 static inline void plx_dr_commit(plx_vertex_t *vertex) {
   pvr_dr_commit((pvr_vertex_t *)vertex);
 }
+
+#define plx_dr_finish pvr_dr_finish
 
 #define plx_prim pvr_prim
 

--- a/include/dr.h
+++ b/include/dr.h
@@ -27,9 +27,17 @@ typedef pvr_vertex_t plx_vertex_t;
 #define PLX_VERT	PVR_CMD_VERTEX
 #define PLX_VERT_EOS	PVR_CMD_VERTEX_EOL
 
-#define plx_dr_init(a) pvr_dr_init(a)
-#define plx_dr_target(a) pvr_dr_target(*a)
-#define plx_dr_commit(a) pvr_dr_commit(a)
+static inline void plx_dr_init(plx_dr_state_t *state) {
+  pvr_dr_init((pvr_dr_state_t *)state);
+}
+
+static inline plx_vertex_t *plx_dr_target(plx_dr_state_t *state) {
+  return (plx_vertex_t *)pvr_dr_target(*(pvr_dr_state_t*)state);
+}
+
+static inline void plx_dr_commit(plx_vertex_t *vertex) {
+  pvr_dr_commit((pvr_vertex_t *)vertex);
+}
 
 #define plx_prim pvr_prim
 

--- a/include/dr.h
+++ b/include/dr.h
@@ -40,9 +40,13 @@ static inline void plx_dr_commit(plx_vertex_t *vertex) {
   pvr_dr_commit((pvr_vertex_t *)vertex);
 }
 
-#define plx_dr_finish pvr_dr_finish
+static inline void plx_dr_finish(void) {
+  pvr_dr_finish();
+}
 
-#define plx_prim pvr_prim
+static inline int plx_prim(void *data, int size) {
+  return pvr_prim(data, size)
+}
 
 static inline void plx_scene_begin() {
 	pvr_wait_ready();

--- a/include/dr.h
+++ b/include/dr.h
@@ -29,23 +29,23 @@ typedef pvr_vertex_t plx_vertex_t;
 #define PLX_VERT_EOS	PVR_CMD_VERTEX_EOL
 
 static inline void plx_dr_init(plx_dr_state_t *state) {
-  pvr_dr_init((pvr_dr_state_t *)state);
+    pvr_dr_init((pvr_dr_state_t *)state);
 }
 
 static inline plx_vertex_t *plx_dr_target(plx_dr_state_t *state) {
-  return (plx_vertex_t *)pvr_dr_target(*(pvr_dr_state_t*)state);
+    return (plx_vertex_t *)pvr_dr_target(*(pvr_dr_state_t*)state);
 }
 
 static inline void plx_dr_commit(plx_vertex_t *vertex) {
-  pvr_dr_commit((pvr_vertex_t *)vertex);
+    pvr_dr_commit((pvr_vertex_t *)vertex);
 }
 
 static inline void plx_dr_finish(void) {
-  pvr_dr_finish();
+    pvr_dr_finish();
 }
 
 static inline int plx_prim(void *data, int size) {
-  return pvr_prim(data, size);
+    return pvr_prim(data, size);
 }
 
 static inline void plx_scene_begin() {

--- a/include/dr.h
+++ b/include/dr.h
@@ -45,7 +45,7 @@ static inline void plx_dr_finish(void) {
 }
 
 static inline int plx_prim(void *data, int size) {
-  return pvr_prim(data, size)
+  return pvr_prim(data, size);
 }
 
 static inline void plx_scene_begin() {


### PR DESCRIPTION
The recent changes to the SQs propagated out and also impacted the PVR Direct Rendering API (which is a tiny wrapper around the SQs). This requires a few slight changes, plus the addition of calling `pvr_dr_finish()` after completing rendering with the DR context.

Also swapped the forwarding macros to static inline functions with strong typing so we can get better warnings if something like this happens again. 