### PR TITLE
Missing dbglog fixes

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -58,27 +58,27 @@
 */
 
 #define PACKED __attribute__((packed))
-typedef struct {
-	uint8	magic[4]		PACKED;
-	uint32	endian			PACKED;
-	uint32	format			PACKED;
-	uint32	txr_width		PACKED;
-	uint32	txr_height		PACKED;
-	int32	max_ascent		PACKED;
-	int32	max_descent		PACKED;
-	uint32	glyph_cnt		PACKED;
+typedef struct PACKED {
+	uint8	magic[4];
+	uint32	endian;
+	uint32	format;
+	uint32	txr_width;
+	uint32	txr_height;
+	int32	max_ascent;
+	int32	max_descent;
+	uint32	glyph_cnt;
 } txfhdr_t;
 
-typedef struct {
-	int16	idx			PACKED;
-	int8	w			PACKED;
-	int8	h			PACKED;
-	int8	x_offset		PACKED;
-	int8	y_offset		PACKED;
-	int8	advance			PACKED;
-	char	padding			PACKED;
-	uint16	x			PACKED;
-	uint16	y			PACKED;
+typedef struct PACKED {
+	int16	idx;
+	int8	w;
+	int8	h;
+	int8	x_offset;
+	int8	y_offset;
+	int8	advance;
+	char	padding;
+	uint16	x;
+	uint16	y;
 } txfglyph_t;
 
 /* This function DEFINITELY has function growth hormone inbalance syndrome,

--- a/src/font.c
+++ b/src/font.c
@@ -11,6 +11,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <kos/fs.h>
+#include <kos/dbglog.h>
+
 #include "font.h"
 #include "prim.h"
 

--- a/src/font.c
+++ b/src/font.c
@@ -59,7 +59,7 @@
 
 #define PACKED __attribute__((packed))
 typedef struct PACKED {
-	uint8	magic[4];
+	char	magic[4];
 	uint32	endian;
 	uint32	format;
 	uint32	txr_width;
@@ -91,7 +91,7 @@ plx_font_t * plx_font_load(const char * fn) {
 	int		i, x, y;
 	float		xstep, ystep, w, h;
 	uint8		* bmtmp = NULL;
-	uint32		bmsize;
+	ssize_t		bmsize;
 	uint16		* txrtmp = NULL;
 	int		stride;
 
@@ -116,7 +116,7 @@ plx_font_t * plx_font_load(const char * fn) {
 		goto fail_2;	/* bail */
 	}
 
-	if (hdr.magic[0] != 0xff || strncmp("txf", hdr.magic+1, 3)) {
+	if ((uint8)hdr.magic[0] != 0xff || strncmp("txf", hdr.magic+1, 3)) {
 		dbglog(DBG_WARNING, "plx_font_load: invalid font file '%s'\n", fn);
 		goto fail_2;	/* bail */
 	}

--- a/src/texture.c
+++ b/src/texture.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <kos/dbglog.h>
+
 #include "texture.h"
 #include <png/png.h>
 #include <jpeg/jpeg.h>


### PR DESCRIPTION
dbglog.h was not being included, and libparallax was relying on it to be included via stdio. In order to remove it from there without breaking it, adding the includes explicitly.

Also some minor warnings cleanups while there.