### PR TITLE
Use correct `pvr_list_t` type rather than `int`.

### DIFF
--- a/include/dr.h
+++ b/include/dr.h
@@ -53,7 +53,7 @@ static inline void plx_scene_begin() {
 	pvr_scene_begin();
 }
 
-static inline void plx_list_begin(int type) {
+static inline void plx_list_begin(pvr_list_t type) {
 	pvr_list_begin(type);
 }
 

--- a/include/font.h
+++ b/include/font.h
@@ -18,7 +18,7 @@ __BEGIN_DECLS
   fntTxf routines, but are written entirely in C.
  */
 
-#include <kos/vector.h>
+#include <dc/vector.h>
 #include "texture.h"
 
 /**


### PR DESCRIPTION
This will be needed to update the pvr API to have `pvr_list_t` as params. As the function is static inline and used transitively in C++ libtsunami, it can't transparently convert from int to the enum type.